### PR TITLE
Update to use stdint types.

### DIFF
--- a/imageload.c
+++ b/imageload.c
@@ -24,13 +24,13 @@ IMG_FILE img_guess(const char *filename)
 }
 
 void
-img_copy_texture(uint16 *dest, uint8 *source, uint32 channels, uint32 stride,
-                 const IMG_INFO *info, uint32 w, uint32 h)
+img_copy_texture(uint16_t *dest, uint8_t *source, uint32_t channels, uint32_t stride,
+                 const IMG_INFO *info, uint32_t w, uint32_t h)
 {
-  uint32 i,j;
-  uint16 *destRow;
-  uint8 *pRow;
-  uint8 r,g,b;
+  uint32_t i,j;
+  uint16_t *destRow;
+  uint8_t *pRow;
+  uint8_t r,g,b;
 
   for(i = 0; i < h; i++)
   {
@@ -241,9 +241,9 @@ int img_load_file(const char *filename, IMG_INFO *info, kos_img_t *img)
 
 int img_load_data(FILE *f, IMG_INFO *info, kos_img_t *img)
 {
-  uint32 channels, rowBytes;
-  uint8 *data = NULL;
-  uint8 allocate = 0;
+  uint32_t channels, rowBytes;
+  uint8_t *data = NULL;
+  uint8_t allocate = 0;
 
   if (info == NULL)
   {
@@ -294,8 +294,8 @@ int img_load_data(FILE *f, IMG_INFO *info, kos_img_t *img)
   if (info->dither_height == 0)
     info->dither_height = img->h;
 
-  img->data = (uint16 *)malloc(sizeof(uint16)*img->w*img->h);
-  img->byte_count = sizeof(uint16)*img->w*img->h;
+  img->data = (uint16_t *)malloc(sizeof(uint16_t)*img->w*img->h);
+  img->byte_count = sizeof(uint16_t)*img->w*img->h;
   img_copy_texture(img->data, data, channels, rowBytes, info,
                    img->w, img->h);
 

--- a/include/imageload.h
+++ b/include/imageload.h
@@ -31,11 +31,11 @@ typedef struct
 {
   IMG_FILE type;
   IMG_ALPHA alpha;
-  uint32 key;
+  uint32_t key;
   IMG_DITHER dither;
-  uint32 dither_width;
-  uint32 dither_height;
-  uint32 noise;
+  uint32_t dither_width;
+  uint32_t dither_height;
+  uint32_t noise;
 } IMG_INFO;
 
 #define IMG_INFO_DEFAULTS {IMG_FILE_GUESS,IMG_ALPHA_NONE,0,IMG_DITHER_NONE,0,0,0}
@@ -52,27 +52,27 @@ int img_load_file(const char *filename, IMG_INFO *info, kos_img_t *img);
  * create a jitter table at compile time
  */
 void jitter_init(void);
-uint8 jitter(uint8 c, uint8 n, uint8 shift, uint8 noise, uint16 x, uint16 y);
+uint8 jitter(uint8_t c, uint8_t n, uint8_t shift, uint8_t noise, uint16_t x, uint16_t y);
 
 /* Format specific loaders */
 
 uint32 readbmp_init(FILE *infile);
-uint8 *readbmp_get_image(uint32 *pChannels, uint32 *pRowbytes,
-                         uint32 *pWidth, uint32 *pHeight);
+uint8 *readbmp_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+                         uint32_t *pWidth, uint32_t *pHeight);
 void readbmp_cleanup(void);
 
 uint32 readpng_init(FILE *infile);
-uint8 *readpng_get_image(uint32 *pChannels, uint32 *pRowbytes,
-                         uint32 *pWidth, uint32 *pHeight);
+uint8 *readpng_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+                         uint32_t *pWidth, uint32_t *pHeight);
 void readpng_cleanup(void);
 
 uint32 readjpeg_init(FILE *infile);
-uint8 *readjpeg_get_image(uint32 *pChannels, uint32 *pRowbytes,
-                         uint32 *pWidth, uint32 *pHeight);
+uint8 *readjpeg_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+                         uint32_t *pWidth, uint32_t *pHeight);
 void readjpeg_cleanup(void);
 
 uint32 readpcx_init(FILE *infile);
-uint8 *readpcx_get_image(uint32 *pChannels, uint32 *pRowbytes,
-			 uint32 *pWidth, uint32 *pHeight);
+uint8 *readpcx_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+			 uint32_t *pWidth, uint32_t *pHeight);
 void readpcx_cleanup(void);
 #endif

--- a/readjpeg.c
+++ b/readjpeg.c
@@ -6,7 +6,7 @@
 static struct jpeg_decompress_struct cinfo;
 static struct jpeg_error_mgr jerr;
 
-uint32 readjpeg_init(FILE *infile)
+uint32_t readjpeg_init(FILE *infile)
 {
     /* Step 1: allocate and initialize JPEG decompression object */
 
@@ -33,10 +33,10 @@ uint32 readjpeg_init(FILE *infile)
 
 /* load n x n textures from jpegs */
 
-uint8 *readjpeg_get_image(uint32 *pChannels, uint32 *pRowbytes, uint32 *pWidth, uint32 *pHeight)
+uint8_t *readjpeg_get_image(uint32_t *pChannels, uint32_t *pRowbytes, uint32_t *pWidth, uint32_t *pHeight)
 {
-  uint32 i;
-  uint8 *ourbuffer;
+  uint32_t i;
+  uint8_t *ourbuffer;
   JSAMPARRAY buffer;
 
   *pRowbytes = cinfo.output_width * cinfo.output_components;
@@ -44,7 +44,7 @@ uint8 *readjpeg_get_image(uint32 *pChannels, uint32 *pRowbytes, uint32 *pWidth, 
   *pWidth = cinfo.output_width;
   *pHeight = cinfo.output_height;
 
-  ourbuffer = (uint8 *)malloc(*pRowbytes**pHeight);
+  ourbuffer = (uint8_t *)malloc(*pRowbytes**pHeight);
 
   buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr) &cinfo, JPOOL_IMAGE, *pRowbytes, 1);
 

--- a/readpcx.c
+++ b/readpcx.c
@@ -12,38 +12,38 @@ typedef struct {
 	char   ver;               /* encoder version number (5)		*/
 	char   enc;               /* encoding code, always 1		*/
 	char   bpp;               /* bits per pixel, 8 in mode 0x13	*/
-	uint16 xmin,ymin;         /* image origin, usually 0,0		*/
-	uint16 xmax,ymax;         /* image dimensions			*/
-	uint16 hres;              /* horizontal resolution value	*/
-	uint16 vres;              /* vertical resolution value		*/
+	uint16_t xmin,ymin;       /* image origin, usually 0,0		*/
+	uint16_t xmax,ymax;       /* image dimensions			*/
+	uint16_t hres;            /* horizontal resolution value	*/
+	uint16_t vres;            /* vertical resolution value		*/
 	char   pal[48];           /* palette (not in mode 0x13)		*/
 	char   reserved;          /* who knows?				*/
 	char   clrplanes;         /* number of planes, 1 in mode 0x13	*/
-	uint16 bpl;               /* bytes per line, 80 in mode 0x13	*/
-	uint16 pltype;            /* Grey or Color palette flag		*/
+	uint16_t bpl;             /* bytes per line, 80 in mode 0x13	*/
+	uint16_t pltype;          /* Grey or Color palette flag		*/
 	char   filler[58];        /* Zsoft wanted a 128 byte header	*/
 } pcx_hdr;
 
 FILE *pcxfile;
 
-uint32 readpcx_init(FILE *infile)
+uint32_t readpcx_init(FILE *infile)
 {
   pcxfile = infile;
   return 0;
 }
 
-uint8 *readpcx_get_image(uint32 *pChannels, uint32 *pRowBytes,
-                         uint32 *pWidth, uint32 *pHeight)
+uint8_t *readpcx_get_image(uint32_t *pChannels, uint32_t *pRowBytes,
+                           uint32_t *pWidth, uint32_t *pHeight)
 {
-  pcx_hdr header;
-  uint32 bytesRead;
-  uint8 *preImage;
-  uint8 *image;
-  uint8 *palette;
-  uint32 numBytes;
-  uint32 i;
-  uint8 pixel;
-  uint8 runlen;
+  pcx_hdr  header;
+  uint32_t bytesRead;
+  uint8_t *preImage;
+  uint8_t *image;
+  uint8_t *palette;
+  uint32_t numBytes;
+  uint32_t i;
+  uint8_t  pixel;
+  uint8_t  runlen;
   
   bytesRead = fread(&header, sizeof(pcx_hdr), 1, pcxfile);
 
@@ -60,12 +60,12 @@ uint8 *readpcx_get_image(uint32 *pChannels, uint32 *pRowBytes,
 
   for(i = 0; i < numBytes;)
   {
-    fread(&pixel, sizeof(uint8), 1, pcxfile);
+    fread(&pixel, sizeof(uint8_t), 1, pcxfile);
 
     if (pixel & 0xc0)
     {
       runlen = (pixel & 0x3f);
-      fread(&pixel, sizeof(uint8), 1, pcxfile);
+      fread(&pixel, sizeof(uint8_t), 1, pcxfile);
       while(runlen--)
         preImage[i++] = pixel;
     }
@@ -74,7 +74,7 @@ uint8 *readpcx_get_image(uint32 *pChannels, uint32 *pRowBytes,
 
   }
 
-  fread(&pixel, sizeof(uint8), 1, pcxfile);
+  fread(&pixel, sizeof(uint8_t), 1, pcxfile);
   palette = malloc(768);
 
   fread(palette, 768, 1, pcxfile);


### PR DESCRIPTION
This was the last piece of in-house software that was using the `<arch/types.h>` types implicitly via the way they were being inappropriately added to `<sys/_types.h>`.