### PR TITLE
Update to stdint types

### DIFF
--- a/imageload.c
+++ b/imageload.c
@@ -1,7 +1,7 @@
-#include "imageload.h"
+#include "include/imageload.h"
 
+#include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #define LOAD565(r, g, b) (((r>>3)<<11) | ((g>>2)<<5) | ((b>>3)))
 #define LOAD1555(r, g, b, a) (((a>>7)<<15)|((r>>3)<<10)|((g>>3)<<5)|((b>>3)))
@@ -10,7 +10,7 @@
 
 IMG_FILE img_guess(const char *filename)
 {
-  uint32 len = strlen(filename);
+  uint32_t len = strlen(filename);
   const char *end = &filename[len-3];
   if (strncasecmp(end,"jpg",3) == 0)
     return IMG_FILE_JPEG;

--- a/include/imageload.h
+++ b/include/imageload.h
@@ -1,7 +1,10 @@
 #ifndef __IMAGELOAD_H__
 #define __IMAGELOAD_H__
 
-#include <kos.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <kos/img.h>
 
 typedef enum
 {
@@ -52,27 +55,27 @@ int img_load_file(const char *filename, IMG_INFO *info, kos_img_t *img);
  * create a jitter table at compile time
  */
 void jitter_init(void);
-uint8 jitter(uint8_t c, uint8_t n, uint8_t shift, uint8_t noise, uint16_t x, uint16_t y);
+uint8_t jitter(uint8_t c, uint8_t n, uint8_t shift, uint8_t noise, uint16_t x, uint16_t y);
 
 /* Format specific loaders */
 
-uint32 readbmp_init(FILE *infile);
-uint8 *readbmp_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+uint32_t readbmp_init(FILE *infile);
+uint8_t *readbmp_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
                          uint32_t *pWidth, uint32_t *pHeight);
 void readbmp_cleanup(void);
 
-uint32 readpng_init(FILE *infile);
-uint8 *readpng_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+uint32_t readpng_init(FILE *infile);
+uint8_t *readpng_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
                          uint32_t *pWidth, uint32_t *pHeight);
 void readpng_cleanup(void);
 
-uint32 readjpeg_init(FILE *infile);
-uint8 *readjpeg_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+uint32_t readjpeg_init(FILE *infile);
+uint8_t *readjpeg_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
                          uint32_t *pWidth, uint32_t *pHeight);
 void readjpeg_cleanup(void);
 
-uint32 readpcx_init(FILE *infile);
-uint8 *readpcx_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+uint32_t readpcx_init(FILE *infile);
+uint8_t *readpcx_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
 			 uint32_t *pWidth, uint32_t *pHeight);
 void readpcx_cleanup(void);
 #endif

--- a/jitter.c
+++ b/jitter.c
@@ -1,4 +1,4 @@
-#include "jitterdefs.h"
+#include "include/jitterdefs.h"
 
 #include <stdlib.h>
 

--- a/readbmp.c
+++ b/readbmp.c
@@ -1,4 +1,4 @@
-#include <kos.h>
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,69 +11,69 @@
 #define BI_BITFIELDS 3
 
 typedef struct {
-  uint16    bfType;
-  uint32   bfSize;
-  uint16    bfReserved1;
-  uint16    bfReserved2;
-  uint32   bfOffBits;
+  uint16_t    bfType;
+  uint32_t   bfSize;
+  uint16_t    bfReserved1;
+  uint16_t    bfReserved2;
+  uint32_t   bfOffBits;
 } BITMAPFILEHEADER;
 
 typedef struct {
-  uint32 bcSize;
-  uint16 bcWidth;
-  uint16 bcHeight;
-  uint16 bcPlanes;
-  uint16 bcBitCount;
+  uint32_t bcSize;
+  uint16_t bcWidth;
+  uint16_t bcHeight;
+  uint16_t bcPlanes;
+  uint16_t bcBitCount;
 } BITMAPCOREHEADER;
 
 typedef struct tagBITMAPINFOHEADER {
-    uint32  biSize;
-    int32  biWidth;
-    int32  biHeight;
-    uint16   biPlanes;
-    uint16   biBitCount;
-    uint32  biCompression;
-    uint32  biSizeImage;
-    int32  biXPelsPerMeter;
-    int32  biYPelsPerMeter;
-    uint32  biClrUsed;
-    uint32  biClrImportant;
+    uint32_t  biSize;
+    int32_t  biWidth;
+    int32_t  biHeight;
+    uint16_t   biPlanes;
+    uint16_t   biBitCount;
+    uint32_t  biCompression;
+    uint32_t  biSizeImage;
+    int32_t  biXPelsPerMeter;
+    int32_t  biYPelsPerMeter;
+    uint32_t  biClrUsed;
+    uint32_t  biClrImportant;
 } BITMAPINFOHEADER;
 
 typedef struct
 {
-  uint8 rgbBlue;
-  uint8 rgbGreen;
-  uint8 rgbRed;
-  uint8 rgbAlpha;
+  uint8_t rgbBlue;
+  uint8_t rgbGreen;
+  uint8_t rgbRed;
+  uint8_t rgbAlpha;
 }RGBQUAD;
 #pragma pack()
 
 
 FILE *bmpfile;
 
-uint32 readbmp_init(FILE *infile)
+uint32_t readbmp_init(FILE *infile)
 {
   bmpfile = infile;
   return 0;
 }
 
-uint8 *readbmp_get_image(uint32 *pChannels, uint32 *pRowbytes,
-                         uint32 *pWidth, uint32 *pHeight)
+uint8_t *readbmp_get_image(uint32_t *pChannels, uint32_t *pRowbytes,
+                         uint32_t *pWidth, uint32_t *pHeight)
 {
   BITMAPINFOHEADER bitmapInfo;
   BITMAPFILEHEADER bitmapFile;
   RGBQUAD *colorTable;
-  uint32 nNumColors;
-  uint8 *ourbuffer, *imageBuffer, *buffer;
-  uint32 rmask = 0xff, gmask = 0xff, bmask = 0xff;
-  uint32 rshift = 0, gshift = 0, bshift = 0;
-  uint32 skip, r, g, b, k;
-  uint32 x, y;
-  uint8 byte;
+  uint32_t nNumColors;
+  uint8_t *ourbuffer, *imageBuffer, *buffer;
+  uint32_t rmask = 0xff, gmask = 0xff, bmask = 0xff;
+  uint32_t rshift = 0, gshift = 0, bshift = 0;
+  uint32_t skip, r, g, b, k;
+  uint32_t x, y;
+  uint8_t byte;
 
   /* read the BITMAPFILEHEADER */
-  uint32 bytesRead = fread(&bitmapFile, 1, sizeof(BITMAPFILEHEADER), bmpfile);
+  uint32_t bytesRead = fread(&bitmapFile, 1, sizeof(BITMAPFILEHEADER), bmpfile);
   if ( bytesRead != sizeof(BITMAPFILEHEADER) ||
        bitmapFile.bfType != 0x4d42 /* 'BM' */)
   {
@@ -117,11 +117,11 @@ uint8 *readbmp_get_image(uint32 *pChannels, uint32 *pRowbytes,
   if (bitmapFile.bfOffBits != 0)
     fseek(bmpfile,bitmapFile.bfOffBits,SEEK_SET);
 
-  imageBuffer = malloc(sizeof(uint8)*bitmapInfo.biSizeImage);
+  imageBuffer = malloc(sizeof(uint8_t) * bitmapInfo.biSizeImage);
   buffer = imageBuffer;
   bytesRead = fread(buffer, 1, bitmapInfo.biSizeImage, bmpfile);
 
-  if ( bytesRead != bitmapInfo.biSizeImage*sizeof(uint8))
+  if ( bytesRead != bitmapInfo.biSizeImage * sizeof(uint8_t))
   {
     free(colorTable);
     free(imageBuffer);
@@ -132,7 +132,7 @@ uint8 *readbmp_get_image(uint32 *pChannels, uint32 *pRowbytes,
   *pRowbytes = bitmapInfo.biWidth**pChannels;
   *pWidth = bitmapInfo.biWidth;
   *pHeight = bitmapInfo.biHeight;
-  ourbuffer = (uint8*)malloc(*pRowbytes**pHeight);
+  ourbuffer = (uint8_t *)malloc(*pRowbytes**pHeight);
 
   if (bitmapInfo.biCompression == BI_BITFIELDS)
   {
@@ -234,9 +234,9 @@ uint8 *readbmp_get_image(uint32 *pChannels, uint32 *pRowbytes,
     {
       for (x = 0; x < bitmapInfo.biWidth; x++)
       {
-        r = ((uint16)(*buffer) & rmask) >> rshift;
-        g = ((uint16)(*buffer) & gmask) >> gshift;
-        b = ((uint16)(*(buffer++)) & bmask) >> bshift;
+        r = ((uint16_t)(*buffer) & rmask) >> rshift;
+        g = ((uint16_t)(*buffer) & gmask) >> gshift;
+        b = ((uint16_t)(*(buffer++)) & bmask) >> bshift;
 
         ourbuffer[(bitmapInfo.biHeight-y-1)**pRowbytes+3*x] = r;
         ourbuffer[(bitmapInfo.biHeight-y-1)**pRowbytes+3*x+1] = g;
@@ -270,9 +270,9 @@ uint8 *readbmp_get_image(uint32 *pChannels, uint32 *pRowbytes,
     {
       for (x = 0; x < bitmapInfo.biWidth; x++)
       {
-        r = ((uint32)(*buffer) & rmask) >> rshift;
-        g = ((uint32)(*buffer) & gmask) >> gshift;
-        b = ((uint32)(*buffer) & bmask) >> bshift;
+        r = ((uint32_t)(*buffer) & rmask) >> rshift;
+        g = ((uint32_t)(*buffer) & gmask) >> gshift;
+        b = ((uint32_t)(*buffer) & bmask) >> bshift;
 
         ourbuffer[(bitmapInfo.biHeight-y-1)**pRowbytes+3*x] = r;
         ourbuffer[(bitmapInfo.biHeight-y-1)**pRowbytes+3*x+1] = g;

--- a/readpcx.c
+++ b/readpcx.c
@@ -2,10 +2,12 @@
 
    readpcx.c
 
-   PCX image loader (_heavily_ stolen from Dan Potters code)
+   PCX image loader (_heavily_ stolen from Megan Potters code)
  */
 
-#include <kos.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 typedef struct {
 	char   mfg;               /* manufacturer, always 0xa0		*/


### PR DESCRIPTION
Only a few had been removed in the previous cleanup. Additionally
narrowed the includes from kos to prevent accidentally pulling
anything in as was being done with `<arch/types.h>`. Per https://github.com/KallistiOS/KallistiOS/issues/840